### PR TITLE
LUM-435 Update entity types documentation

### DIFF
--- a/source/includes/_entity_types.md
+++ b/source/includes/_entity_types.md
@@ -7,7 +7,17 @@ curl --request GET \
   --url 'https://public-api.lumiformapp.com/api/v2/entity-types' \
   --header 'Authorization: Bearer [your token here]' \
   --header 'Accept: application/json' \
-  --header 'Content-Type: application/json' 
+  --header 'Content-Type: application/json'
+```
+
+> To include properties in the response, add the `include_properties` query parameter:
+
+```shell
+curl --request GET \
+  --url 'https://public-api.lumiformapp.com/api/v2/entity-types?include_properties=true' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json'
 ```
 
 > The above command returns JSON structured like this:
@@ -66,11 +76,80 @@ curl --request GET \
 }
 ```
 
-This endpoint retrieves all of your entity types.
+This endpoint retrieves all of your entity types. By default, properties are not included in the response. To include them, use the `include_properties=true` query parameter.
 
 ### HTTP Request
 
 `GET https://public-api.lumiformapp.com/api/v2/entity-types`
+
+### Response with Properties
+
+When `include_properties=true` is included in the query string, the response will include a `properties` array for each entity type:
+
+> Properties included in response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "title": "Safety checklist",
+      "description": "This checklist is about safety",
+      "properties": [
+        {
+          "id": 1,
+          "label": "Location",
+          "data_type": "text",
+          "allow_multi": false
+        },
+        {
+          "id": 2,
+          "label": "Status",
+          "data_type": "dropdown",
+          "option_set_id": 1,
+          "allow_multi": false,
+          "option_values": [
+            {
+              "id": 1,
+              "label": "Active"
+            },
+            {
+              "id": 2,
+              "label": "Inactive"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "links": {
+    "first": "https://public-api.lumiformapp.com/api/v2/entity-types?page=1&include_properties=true",
+    "last": "https://public-api.lumiformapp.com/api/v2/entity-types?page=2&include_properties=true",
+    "prev": null,
+    "next": "https://public-api.lumiformapp.com/api/v2/entity-types?page=2&include_properties=true"
+  },
+  "meta": {
+    "current_page": 1,
+    "from": 1,
+    "last_page": 2,
+    "path": "https://public-api.lumiformapp.com/api/v2/entity-types",
+    "per_page": 15,
+    "to": 15,
+    "total": 30
+  }
+}
+```
+
+**Properties Field Details:**
+
+- **`id`** - The unique identifier of the property definition
+- **`label`** - The display label of the property
+- **`data_type`** - The type of property: `"text"` or `"dropdown"`
+- **`allow_multi`** - Whether multiple values are allowed for this property
+- **`option_set_id`** - The ID of the option set (only present for dropdown-type properties)
+- **`option_values`** - Array of available option values (only present for dropdown-type properties). Each option value contains:
+  - **`id`** - The unique identifier of the option value
+  - **`label`** - The display label of the option
 
 ### Query Parameters
 
@@ -78,6 +157,7 @@ This endpoint retrieves all of your entity types.
 |-------------| ------- | ---- | ------- | ----------- |
 | page        | No | Number | 1 | The results page number to view. If omitted, the default is 1. |
 | title       | No | Text | warehouse | A string of text to try and find in the entity types titles. |
+| include_properties | No | Boolean | true | When set to `true`, includes property definitions for each entity type. Defaults to `false`. |
 
 ## Get a Specific Entity Type
 
@@ -86,7 +166,17 @@ curl --request GET \
   --url 'https://public-api.lumiformapp.com/api/v2/entity-types/1' \
   --header 'Authorization: Bearer [your token here]' \
   --header 'Accept: application/json' \
-  --header 'Content-Type: application/json' 
+  --header 'Content-Type: application/json'
+```
+
+> To include properties in the response, add the `include_properties` query parameter:
+
+```shell
+curl --request GET \
+  --url 'https://public-api.lumiformapp.com/api/v2/entity-types/1?include_properties=true' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json'
 ```
 
 > The above command returns JSON structured like this:
@@ -101,7 +191,44 @@ curl --request GET \
 }
 ```
 
-This endpoint retrieves a specific Entity Type.
+> When `include_properties=true` is included, the response will also contain a `properties` array:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "title": "Safety checklist",
+    "description": "This checklist is about safety",
+    "properties": [
+      {
+        "id": 1,
+        "label": "Location",
+        "data_type": "text",
+        "allow_multi": false
+      },
+      {
+        "id": 2,
+        "label": "Status",
+        "data_type": "dropdown",
+        "option_set_id": 1,
+        "allow_multi": false,
+        "option_values": [
+          {
+            "id": 1,
+            "label": "Active"
+          },
+          {
+            "id": 2,
+            "label": "Inactive"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This endpoint retrieves a specific Entity Type. By default, properties are not included in the response. To include them, use the `include_properties=true` query parameter.
 
 ### HTTP Request
 
@@ -113,8 +240,13 @@ This endpoint retrieves a specific Entity Type.
 |-----------------| ------- | ---- | ------- | ----------- |
 | EntityTypeId  | Yes | Number | 1 | The Id of the entity type to retrieve. |
 
-## Create an Entity Type
+### Query Parameters
 
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| include_properties | No | Boolean | true | When set to `true`, includes property definitions for the entity type. Defaults to `false`. |
+
+## Create an Entity Type
 
 ```shell
 curl --request POST \
@@ -122,7 +254,18 @@ curl --request POST \
   --header 'Authorization: Bearer [your token here]' \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --d '{"title":"Tatooine","description":"Some description"}'
+  --data '{"title":"Tatooine","description":"Some description"}'
+```
+
+> To create an entity type with property definitions, include the `properties` array:
+
+```shell
+curl --request POST \
+  --url 'https://public-api.lumiformapp.com/api/v2/entity-types' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{"title":"Tatooine","description":"Some description","properties":[{"label":"Location","dataType":"text","allowMulti":false},{"label":"Status","dataType":"dropdown","optionSetId":1,"allowMulti":false}]}'
 ```
 
 > The above command returns JSON structured like this:
@@ -139,6 +282,27 @@ This endpoint creates an Entity Type.
 
 `POST https://public-api.lumiformapp.com/api/v2/entity-types`
 
+### Request Body Parameters
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| title | Yes | String | "Tatooine" | The title of the entity type. |
+| description | No | String | "Some description" | The description of the entity type. |
+| properties | No | Array | See below | Array of property definitions to create for this entity type. |
+
+**Properties Array Structure:**
+
+Each property object in the `properties` array should contain:
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| label | Yes* | String | "Location" | The display label of the property. Required when `properties` array is provided. |
+| dataType | Yes* | String | "text" or "dropdown" | The data type of the property. Must be either `"text"` or `"dropdown"`. Required when `properties` array is provided. |
+| optionSetId | No | Number | 1 | The ID of the option set. Required when `dataType` is `"dropdown"`. Not used for `"text"` properties. |
+| allowMulti | No | Boolean | false | Whether multiple values are allowed for this property. Defaults to `false`. |
+
+**Note:** For dropdown properties, `optionSetId` is required. For text properties, `optionSetId` should not be provided.
+
 ## Update an Entity Type
 
 ```shell
@@ -147,7 +311,18 @@ curl --request PUT \
   --header 'Authorization: Bearer [your token here]' \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --d '{"title":"Tatooine","description":"Some description"}'
+  --data '{"title":"Tatooine","description":"Some description"}'
+```
+
+> To update an entity type with property definitions, include the `properties` array:
+
+```shell
+curl --request PUT \
+  --url 'https://public-api.lumiformapp.com/api/v2/entity-types/1' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{"title":"Tatooine","description":"Some description","properties":[{"id":5,"label":"Updated Location","dataType":"text","allowMulti":false},{"label":"New Status","dataType":"dropdown","optionSetId":1,"allowMulti":false}]}'
 ```
 
 > The above command does not return any data
@@ -164,6 +339,28 @@ This endpoint updates a specific Entity Type.
 |----------------|----------|--------|---------|----------------------------------------|
 | EntityTypeId | Yes      | Number | 1       | The Id of the Entity Type to update. |
 
+### Request Body Parameters
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| title | Yes | String | "Tatooine" | The title of the entity type. |
+| description | No | String | "Some description" | The description of the entity type. |
+| properties | No | Array | See below | Array of property definitions to update or create for this entity type. |
+
+**Properties Array Structure:**
+
+Each property object in the `properties` array should contain:
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| id | No | Number | 5 | The ID of an existing property to update. Omit to create a new property. |
+| label | Yes* | String | "Updated Location" | The display label of the property. Required when `properties` array is provided. |
+| dataType | Yes* | String | "text" or "dropdown" | The data type of the property. Must be either `"text"` or `"dropdown"`. Required when `properties` array is provided. |
+| optionSetId | No | Number | 1 | The ID of the option set. Required when `dataType` is `"dropdown"`. Not used for `"text"` properties. |
+| allowMulti | No | Boolean | false | Whether multiple values are allowed for this property. Defaults to `false`. |
+
+**Note:** For dropdown properties, `optionSetId` is required. For text properties, `optionSetId` should not be provided. Include `id` to update an existing property, or omit it to create a new property.
+
 ## Delete an Entity Type
 
 ```shell
@@ -171,7 +368,7 @@ curl --request DELETE \
   --url 'https://public-api.lumiformapp.com/api/v2/entity-types/1' \
   --header 'Authorization: Bearer [your token here]' \
   --header 'Accept: application/json' \
-  --header 'Content-Type: application/json' 
+  --header 'Content-Type: application/json'
 ```
 
 > The above command does not return any data

--- a/source/includes/_response_sets.md
+++ b/source/includes/_response_sets.md
@@ -1,0 +1,323 @@
+# Entity Type Response Sets
+
+## Get All Entity Type Response Sets
+
+```shell
+curl --request GET \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json'
+```
+
+> To include option values in the response, add the `include_option_values` query parameter:
+
+```shell
+curl --request GET \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets?include_option_values=true' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "Priority Levels"
+    },
+    {
+      "id": 2,
+      "name": "Status Options"
+    }
+  ],
+  "links": {
+    "first": "https://public-api.lumiformapp.com/api/v2/response-sets?page=1",
+    "last": "https://public-api.lumiformapp.com/api/v2/response-sets?page=2",
+    "prev": null,
+    "next": "https://public-api.lumiformapp.com/api/v2/response-sets?page=2"
+  },
+  "meta": {
+    "current_page": 1,
+    "from": 1,
+    "last_page": 2,
+    "links": [
+      {
+        "url": null,
+        "label": "&laquo; Previous",
+        "active": false
+      },
+      {
+        "url": "https://public-api.lumiformapp.com/api/v2/response-sets?page=1",
+        "label": "1",
+        "active": true
+      },
+      {
+        "url": "https://public-api.lumiformapp.com/api/v2/response-sets?page=2",
+        "label": "2",
+        "active": false
+      },
+      {
+        "url": "https://public-api.lumiformapp.com/api/v2/response-sets?page=2",
+        "label": "Next &raquo;",
+        "active": false
+      }
+    ],
+    "path": "https://public-api.lumiformapp.com/api/v2/response-sets",
+    "per_page": 15,
+    "to": 15,
+    "total": 30
+  }
+}
+```
+
+This endpoint retrieves all of your entity type response sets. By default, option values are not included in the response. To include them, use the `include_option_values=true` query parameter.
+
+### HTTP Request
+
+`GET https://public-api.lumiformapp.com/api/v2/response-sets`
+
+### Response with Option Values
+
+When `include_option_values=true` is included in the query string, the response will include an `option_values` array for each entity type response set:
+
+> Option values included in response:
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "Priority Levels",
+      "option_values": [
+        {
+          "id": 1,
+          "label": "High"
+        },
+        {
+          "id": 2,
+          "label": "Medium"
+        },
+        {
+          "id": 3,
+          "label": "Low"
+        }
+      ]
+    }
+  ],
+  "links": {
+    "first": "https://public-api.lumiformapp.com/api/v2/response-sets?page=1&include_option_values=true",
+    "last": "https://public-api.lumiformapp.com/api/v2/response-sets?page=2&include_option_values=true",
+    "prev": null,
+    "next": "https://public-api.lumiformapp.com/api/v2/response-sets?page=2&include_option_values=true"
+  },
+  "meta": {
+    "current_page": 1,
+    "from": 1,
+    "last_page": 2,
+    "path": "https://public-api.lumiformapp.com/api/v2/response-sets",
+    "per_page": 15,
+    "to": 15,
+    "total": 30
+  }
+}
+```
+
+**Option Values Field Details:**
+
+- **`id`** - The unique identifier of the option value
+- **`label`** - The display label of the option value
+
+### Query Parameters
+
+| Parameter   | Required | Type | Example | Description |
+|-------------| ------- | ---- | ------- | ----------- |
+| page        | No | Number | 1 | The results page number to view. If omitted, the default is 1. |
+| name        | No | Text | priority | A string of text to try and find in the entity type response set names. |
+| include_option_values | No | Boolean | true | When set to `true`, includes option values for each entity type response set. Defaults to `false`. |
+
+## Get a Specific Entity Type Response Set
+
+```shell
+curl --request GET \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets/1' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": 1,
+    "name": "Priority Levels",
+    "option_values": [
+      {
+        "id": 1,
+        "label": "High"
+      },
+      {
+        "id": 2,
+        "label": "Medium"
+      },
+      {
+        "id": 3,
+        "label": "Low"
+      }
+    ]
+  }
+}
+```
+
+This endpoint retrieves a specific Entity Type Response Set with its option values.
+
+### HTTP Request
+
+`GET https://public-api.lumiformapp.com/api/v2/response-sets/<ResponseSetId>`
+
+### URL Parameters
+
+| Parameter       | Required | Type | Example | Description |
+|-----------------| ------- | ---- | ------- | ----------- |
+| ResponseSetId  | Yes | Number | 1 | The Id of the entity type response set to retrieve. |
+
+## Create an Entity Type Response Set
+
+```shell
+curl --request POST \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{"name":"Priority Levels"}'
+```
+
+> To create an entity type response set with option values, include the `optionValues` array:
+
+```shell
+curl --request POST \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{"name":"Priority Levels","optionValues":[{"label":"High","value":"high","isActive":true},{"label":"Medium","value":"medium","isActive":true},{"label":"Low","value":"low","isActive":true}]}'
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": 1
+}
+```
+
+This endpoint creates an Entity Type Response Set.
+
+### HTTP Request
+
+`POST https://public-api.lumiformapp.com/api/v2/response-sets`
+
+### Request Body Parameters
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| name | Yes | String | "Priority Levels" | The name of the entity type response set. Must be unique within your organization. |
+| optionValues | No | Array | See below | Array of option values to create for this entity type response set. |
+
+**Option Values Array Structure:**
+
+Each option value object in the `optionValues` array should contain:
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| label | Yes* | String | "High" | The display label of the option value. Required when `optionValues` array is provided. |
+| value | No | String | "high" | The value of the option. Can be null. |
+| isActive | No | Boolean | true | Whether the option value is active. Defaults to `true`. |
+
+**Note:** The `name` field must be unique within your organization. If an entity type response set with the same name already exists, the request will fail with a validation error.
+
+## Update an Entity Type Response Set
+
+```shell
+curl --request PUT \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets/1' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{"name":"Priority Levels Updated"}'
+```
+
+> To update an entity type response set with option values, include the `optionValues` array:
+
+```shell
+curl --request PUT \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets/1' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{"name":"Priority Levels Updated","optionValues":[{"id":1,"label":"High Updated","value":"high","isActive":true},{"label":"New Option","value":"new","isActive":true}]}'
+```
+
+> The above command does not return any data
+
+This endpoint updates a specific Entity Type Response Set. When updating option values, existing values not included in the request will be deleted.
+
+### HTTP Request
+
+`PUT https://public-api.lumiformapp.com/api/v2/response-sets/<ResponseSetId>`
+
+### URL Parameters
+
+| Parameter      | Required | Type   | Example | Description                            |
+|----------------|----------|--------|---------|----------------------------------------|
+| ResponseSetId | Yes      | Number | 1       | The Id of the Entity Type Response Set to update. |
+
+### Request Body Parameters
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| name | Yes | String | "Priority Levels Updated" | The name of the entity type response set. Must be unique within your organization. |
+| optionValues | No | Array | See below | Array of option values to update or create for this entity type response set. |
+
+**Option Values Array Structure:**
+
+Each option value object in the `optionValues` array should contain:
+
+| Parameter  | Required | Type | Example | Description                                                    |
+|------------| ------- | ---- | ------ |----------------------------------------------------------------|
+| id | No | Number | 1 | The ID of an existing option value to update. Omit to create a new option value. |
+| label | Yes* | String | "High Updated" | The display label of the option value. Required when `optionValues` array is provided. |
+| value | No | String | "high" | The value of the option. Can be null. |
+| isActive | No | Boolean | true | Whether the option value is active. |
+
+**Note:** The `name` field must be unique within your organization. Include `id` to update an existing option value, or omit it to create a new option value. Existing option values not included in the `optionValues` array will be deleted.
+
+## Delete an Entity Type Response Set
+
+```shell
+curl --request DELETE \
+  --url 'https://public-api.lumiformapp.com/api/v2/response-sets/1' \
+  --header 'Authorization: Bearer [your token here]' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json'
+```
+
+> The above command does not return any data
+
+This endpoint deletes a specific Entity Type Response Set. Note that you cannot delete an entity type response set if it is being used by any entity type properties.
+
+### HTTP Request
+
+`DELETE https://public-api.lumiformapp.com/api/v2/response-sets/<ResponseSetId>`
+
+### URL Parameters
+
+| Parameter      | Required | Type   | Example | Description                            |
+|----------------|----------|--------|---------|----------------------------------------|
+| ResponseSetId | Yes      | Number | 1       | The Id of the Entity Type Response Set to delete. |
+

--- a/source/includes/_response_sets.md
+++ b/source/includes/_response_sets.md
@@ -205,7 +205,26 @@ curl --request POST \
   --header 'Authorization: Bearer [your token here]' \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --data '{"name":"Priority Levels","optionValues":[{"label":"High","value":"high","isActive":true},{"label":"Medium","value":"medium","isActive":true},{"label":"Low","value":"low","isActive":true}]}'
+  --data '{
+    "name": "Priority Levels",
+    "optionValues": [
+      {
+        "label": "High",
+        "value": "high",
+        "isActive": true
+      },
+      {
+        "label": "Medium",
+        "value": "medium",
+        "isActive": true
+      },
+      {
+        "label": "Low",
+        "value": "low",
+        "isActive": true
+      }
+    ]
+  }'
 ```
 
 > The above command returns JSON structured like this:
@@ -260,7 +279,22 @@ curl --request PUT \
   --header 'Authorization: Bearer [your token here]' \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
-  --data '{"name":"Priority Levels Updated","optionValues":[{"id":1,"label":"High Updated","value":"high","isActive":true},{"label":"New Option","value":"new","isActive":true}]}'
+  --data '{
+    "name": "Priority Levels Updated",
+    "optionValues": [
+      {
+        "id": 1,
+        "label": "High Updated",
+        "value": "high",
+        "isActive": true
+      },
+      {
+        "label": "New Option",
+        "value": "new",
+        "isActive": true
+      }
+    ]
+  }'
 ```
 
 > The above command does not return any data

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -20,6 +20,7 @@ includes:
   - sites
   - entity_folders
   - entity_types
+  - response_sets
   - entity_items
   - users
 


### PR DESCRIPTION
https://linear.app/lumiformapp/issue/LUM-435

Update entity types API documentation to include `include_properties` query parameter for `index` and `show` endpoints. Add `properties` array support documentation for `create` and `update` endpoints. Format matches entity items documentation style.